### PR TITLE
upgrade libtorch to v2.1.0 for macOS

### DIFF
--- a/deps/build_dylib_macos.sh
+++ b/deps/build_dylib_macos.sh
@@ -18,7 +18,7 @@ mkdir -p $PROJECT_DIR/csrc/build
 cd $PROJECT_DIR/csrc/build
 rm -f *.zip
 rm -fr libtorch/
-wget https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.7.1.zip
+wget https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip
 unzip *.zip
 LIBTORCH_PATH=$PWD/libtorch
 

--- a/deps/build_dylib_macos.sh
+++ b/deps/build_dylib_macos.sh
@@ -18,7 +18,7 @@ mkdir -p $PROJECT_DIR/csrc/build
 cd $PROJECT_DIR/csrc/build
 rm -f *.zip
 rm -fr libtorch/
-wget https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip
+wget https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip
 unzip *.zip
 LIBTORCH_PATH=$PWD/libtorch
 


### PR DESCRIPTION
Libtorch started to support arm64 from v2.2.0, but we are using v2.1.0 now.